### PR TITLE
add set_download_directory method and global variable __download_dir__

### DIFF
--- a/bradata/__init__.py
+++ b/bradata/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pkg_resources
+import bradata.utils
 
 from .infraero import Infraero
 
@@ -7,3 +8,5 @@ try:
     __version__ = pkg_resources.get_distribution(__name__).version
 except:
     __version__ = 'unknown'
+
+__download_dir__ = bradata.utils.set_download_directory()

--- a/bradata/utils.py
+++ b/bradata/utils.py
@@ -1,3 +1,5 @@
+import os
+
 def _make_url(api_house=None, base_url= None, params=None):
     """
     It builds the url based on the house webservice and parameters
@@ -83,3 +85,16 @@ def _must_contain(this=None, keys=None):
 
     else:
         return True
+
+def set_download_directory(user_path=None):
+    if user_path is None:
+        user_path = os.path.expanduser('~')
+    download_path = os.path.join(user_path, "bradata_download")
+    try:
+        os.makedirs(download_path)
+    except FileExistsError:
+        pass
+    except PermissionError:
+        user_path = input("bradata doesn't seem to have the permission to write to the default download directory. please specify your desired download path:\n ")
+        download_path = set_download_directory(user_path)  # to check if provided path is writable
+    return download_path


### PR DESCRIPTION
now all submodules that download data should check `bradata.__download_dir__` for the correct path.

when importing the bradata module, it looks for the user's home directory. if for some reason it doesn't have permission to write to it, it asks the user for a path.

#### to-do

- [ ] check if this works well on windows (w/ and w/o anaconda)
- [ ] implement persistence to store global variables across reboots (high priority if there are other variables to be stored)
- [ ] implement  change_download_dir method (low priority)